### PR TITLE
Potential fix for code scanning alert no. 119: Client-side cross-site scripting

### DIFF
--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -516,12 +516,12 @@
         // Add the first entry (workflow level)
         baseParams.set(`name_0`, nameArray[0]);
         pathNames.push(nameArray[0]);
-        pathLinks.push(`<span class="separator">/</span><a href="${window.location.pathname}?${baseParams.toString()}">${nameArray[0]}</a>`);
+        pathLinks.push(`<span class="separator">/</span><a href="${window.location.pathname}?${encodeURIComponent(baseParams.toString())}">${encodeURIComponent(nameArray[0])}</a>`);
         // Add the second entry (job level)
         if (nameArray.length > 1) {
             baseParams.set(`name_1`, nameArray[1]);
             pathNames.push(nameArray[1]);
-            pathLinks.push(`<span class="separator">/</span><a href="${window.location.pathname}?${baseParams.toString()}">${nameArray[1]}</a>`);
+            pathLinks.push(`<span class="separator">/</span><a href="${window.location.pathname}?${encodeURIComponent(baseParams.toString())}">${encodeURIComponent(nameArray[1])}</a>`);
         }
         // Iterate through the nameArray starting at index 0
         for (const [index, name] of nameArray.entries()) {
@@ -531,7 +531,7 @@
                 if (nextResult) {
                     baseParams.set(`name_${index}`, nextResult.name);
                     pathNames.push(nextResult.name);  // Correctly push nextResult name, not currentObj.name
-                    pathLinks.push(`<span class="separator">/</span><a href="${window.location.pathname}?${baseParams.toString()}">${nextResult.name}</a>`);
+                    pathLinks.push(`<span class="separator">/</span><a href="${window.location.pathname}?${encodeURIComponent(baseParams.toString())}">${encodeURIComponent(nextResult.name)}</a>`);
                     currentObj = nextResult; // Move to the next object in the hierarchy
                 } else {
                     console.error(`Name "${name}" not found in results array.`);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/119](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/119)

To fix the issue, we need to sanitize or encode the user-provided input before injecting it into the DOM. The best approach is to use a library like `DOMPurify` to sanitize the HTML content or encode the values using `encodeURIComponent` or a similar method to ensure that the input is safe. In this case, we will use `encodeURIComponent` to encode the query parameter values before constructing the HTML links. This ensures that any special characters in the user input are safely escaped, preventing XSS attacks.

Changes will be made to the `navigatePath` function:
1. Replace the direct use of `baseParams.toString()` in constructing `pathLinks` with a sanitized version where each parameter value is encoded using `encodeURIComponent`.
2. Ensure that the final `pathLinks.join('')` is safe to inject into the DOM.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
