### PR TITLE
Potential fix for code scanning alert no. 136: Default version of SSL/TLS may be insecure

### DIFF
--- a/tests/integration/test_dictionary_custom_settings/http_server.py
+++ b/tests/integration/test_dictionary_custom_settings/http_server.py
@@ -74,9 +74,10 @@ def start_server(server_address, data_path, schema, cert_path, address_family):
         HTTPServer.address_family = socket.AF_INET6
     httpd = HTTPServer(server_address, TSVHTTPHandler)
     if schema == "https":
-        httpd.socket = ssl.wrap_socket(
-            httpd.socket, certfile=cert_path, server_side=True
-        )
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        context.load_cert_chain(certfile=cert_path)
+        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     httpd.serve_forever()
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/136](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/136)

To fix the issue, replace the use of `ssl.wrap_socket` with `ssl.SSLContext` or `ssl.create_default_context`. These methods allow for explicit control over the protocol version and other security settings. Specifically, we will use `ssl.create_default_context` and set the `minimum_version` to `ssl.TLSVersion.TLSv1_2` to ensure that only secure protocols are used. This change will make the server more secure while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
