### PR TITLE
Potential fix for code scanning alert no. 135: Uncontrolled data used in path expression

### DIFF
--- a/docker/test/integration/hive_server/http_api_server.py
+++ b/docker/test/integration/hive_server/http_api_server.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from werkzeug.utils import secure_filename
 import subprocess
 
 from flask import Flask, flash, redirect, request, url_for
@@ -49,8 +50,12 @@ def upload_file():
             flash("No selected file")
             return redirect(request.url)
         if file and allowed_file(file.filename):
-            filename = file.filename
-            file.save(os.path.join(app.config["UPLOAD_FOLDER"], filename))
+            filename = secure_filename(file.filename)
+            fullpath = os.path.normpath(os.path.join(app.config["UPLOAD_FOLDER"], filename))
+            if not fullpath.startswith(os.path.abspath(app.config["UPLOAD_FOLDER"])):
+                flash("Invalid file path")
+                return redirect(request.url)
+            file.save(fullpath)
             return redirect(url_for("upload_file", name=filename))
     return """
     <!doctype html>


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/135](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/135)

To fix the issue, we need to validate and sanitize the `filename` before using it in the `os.path.join` function. The best approach is to use `werkzeug.utils.secure_filename`, which ensures that the filename is safe by removing any special characters and path traversal components. Additionally, we should normalize the resulting path and verify that it resides within the `UPLOAD_FOLDER` to prevent directory traversal attacks.

Steps to fix:
1. Import `secure_filename` from `werkzeug.utils`.
2. Replace the direct use of `file.filename` with `secure_filename(file.filename)` to sanitize the filename.
3. Normalize the resulting path using `os.path.normpath` and ensure it starts with the `UPLOAD_FOLDER` to confirm it is within the intended directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
