### PR TITLE
Potential fix for code scanning alert no. 131: Clear-text logging of sensitive information

### DIFF
--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -115,7 +115,8 @@ class Shell:
     @classmethod
     def get_output(cls, command, strict=False, verbose=False):
         if verbose:
-            print(f"Run command [{command}]")
+            sanitized_command = cls.sanitize_command(command)
+            print(f"Run command [{sanitized_command}]")
         res = subprocess.run(
             command,
             shell=True,
@@ -141,6 +142,16 @@ class Shell:
             text=True,
         )
         return res.returncode, res.stdout.strip(), res.stderr.strip()
+
+    @classmethod
+    def sanitize_command(cls, command: str) -> str:
+        """
+        Redacts sensitive information from a command string.
+        For example, replaces secrets or keys with '***'.
+        """
+        # Example: Redact AWS secret keys or other patterns
+        redacted_command = re.sub(r'(--secret-id\s+\S+|--query\s+\S+)', r'--redacted ***', command)
+        return redacted_command
 
     @classmethod
     def check(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/131](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/131)

To fix the issue, we should avoid logging sensitive data directly. Instead of logging the full command, we can log a sanitized or redacted version of it. For example, we can replace sensitive parts of the command with placeholders (e.g., `***`). This ensures that sensitive information is not exposed in the logs while still providing useful debugging information.

The fix involves:
1. Modifying the `Shell.get_output` method to sanitize the `command` variable before logging it.
2. Adding a helper function to sanitize commands by redacting sensitive information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
