### PR TITLE
Potential fix for code scanning alert no. 130: Clear-text logging of sensitive information

### DIFF
--- a/tests/integration/test_dictionaries_ddl/test.py
+++ b/tests/integration/test_dictionaries_ddl/test.py
@@ -60,8 +60,8 @@ node5 = cluster.add_instance(
 
 def create_mysql_conn(user, password, hostname, port):
     logging.debug(
-        "Created MySQL connection user:{}, password:{}, host:{}, port{}".format(
-            user, password, hostname, port
+        "Created MySQL connection user:{}, host:{}, port{}".format(
+            user, hostname, port
         )
     )
     return pymysql.connect(user=user, password=password, host=hostname, port=port)


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/130](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/130)

To fix the issue, we should avoid logging sensitive information such as passwords. Instead, we can log non-sensitive details like the username, hostname, and port, which are sufficient for debugging purposes. The `password` parameter should be excluded from the log message entirely.

The fix involves modifying the logging statement on line 63 to remove the `password` field. No additional imports or dependencies are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
