### PR TITLE
Potential fix for code scanning alert no. 129: Clear-text logging of sensitive information

### DIFF
--- a/tests/ci/performance_comparison_check.py
+++ b/tests/ci/performance_comparison_check.py
@@ -169,7 +169,8 @@ def main():
         docker_env,
         docker_image,
     )
-    logging.info("Going to run command %s", run_command)
+    sanitized_run_command = run_command.replace(database_password, "***")
+    logging.info("Going to run command %s", sanitized_run_command)
 
     run_log_path = temp_path / "run.log"
     compare_log_path = result_path / "compare.log"


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/129](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/129)

To fix the issue, we should ensure that sensitive information such as `database_password` is not logged. Instead of logging the full `run_command` string, we can sanitize it by replacing sensitive values with placeholders (e.g., `***`). This approach retains the usefulness of the log for debugging while protecting sensitive data.

The fix involves:
1. Identifying sensitive keys in `env_extra` (e.g., `CLICKHOUSE_PERFORMANCE_COMPARISON_DATABASE_USER_PASSWORD`).
2. Replacing their values with a placeholder (e.g., `***`) in the `run_command` string before logging it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
