### PR TITLE
Potential fix for code scanning alert no. 144: Clear-text logging of sensitive information

### DIFF
--- a/tests/ci/performance_comparison_check.py
+++ b/tests/ci/performance_comparison_check.py
@@ -170,7 +170,7 @@ def main():
         docker_image,
     )
     sanitized_run_command = run_command.replace(database_password, "***")
-    logging.info("Going to run command %s", sanitized_run_command)
+    logging.info("Preparing to execute the performance comparison command.")
 
     run_log_path = temp_path / "run.log"
     compare_log_path = result_path / "compare.log"


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/144](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/144)

To fix the issue, we should avoid logging the entire `sanitized_run_command` string, as it may inadvertently include sensitive information. Instead, we can log a generic message indicating that the command is being executed, without including the command details. This ensures that no sensitive data is exposed in the logs.

Steps to implement the fix:
1. Replace the logging statement on line 173 with a generic message that does not include the `sanitized_run_command`.
2. Ensure that no sensitive information is logged elsewhere in the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
