### PR TITLE
Potential fix for code scanning alert no. 128: Clear-text logging of sensitive information

### DIFF
--- a/tests/integration/helpers/external_sources.py
+++ b/tests/integration/helpers/external_sources.py
@@ -76,7 +76,7 @@ class SourceMySQL(ExternalSource):
 
     def create_mysql_conn(self):
         logging.debug(
-            f"pymysql connect {self.user}, {self.password}, {self.internal_hostname}, {self.internal_port}"
+            f"pymysql connect {self.user}, {self.internal_hostname}, {self.internal_port}"
         )
         self.connection = pymysql.connect(
             user=self.user,


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/128](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/128)

To fix the issue, we will remove the sensitive information (`self.password`) from the log message. Instead, we will log only non-sensitive information, such as the username and hostname, which are not considered sensitive in this context. This ensures that the log message remains useful for debugging purposes without exposing sensitive data.

We will modify the log message on line 79 to exclude `self.password`. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
