### PR TITLE
Potential fix for code scanning alert no. 127: Clear-text logging of sensitive information

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4574,7 +4574,7 @@ class ClickHouseInstance:
                 base_secrets_dir = self.path
             from_dir = self.secrets_dir
             to_dir = p.abspath(p.join(base_secrets_dir, "secrets"))
-            logging.debug(f"Copy secret from {from_dir} to {to_dir}")
+            logging.debug("Copying secret to the target directory.")
             shutil.copytree(
                 self.secrets_dir,
                 p.abspath(p.join(base_secrets_dir, "secrets")),


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/127](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/127)

To fix the issue, we should avoid logging sensitive information directly. Instead of logging the full paths (`from_dir` and `to_dir`), we can log a generic message that does not include sensitive details. For example, we can log that a secret is being copied without specifying the exact source and destination paths. This ensures that sensitive data is not exposed while still providing useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
