### PR TITLE
Potential fix for code scanning alert no. 124: Clear-text logging of sensitive information

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3514,6 +3514,8 @@ class ClickHouseInstance:
             sql_for_log = sql[:1000]
         else:
             sql_for_log = sql
+        # Mask sensitive information in the SQL query
+        sql_for_log = re.sub(r"IDENTIFIED BY\s+'[^']*'", "IDENTIFIED BY '***'", sql_for_log)
         logging.debug("Executing query %s on %s", sql_for_log, self.name)
         return self.client.query(
             sql,


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/124](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/124)

To fix the issue, we need to ensure that sensitive data such as passwords is not logged. This can be achieved by masking or redacting sensitive information in the SQL query before logging it. Specifically:
1. Identify patterns in the SQL query that may contain sensitive data (e.g., `IDENTIFIED BY 'password'`).
2. Replace the sensitive data with a placeholder (e.g., `IDENTIFIED BY '***'`) before logging the query.
3. Ensure that the masking logic is applied consistently to all SQL queries logged by the `query` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
