### PR TITLE
Potential fix for code scanning alert no. 142: URL redirection from remote source

### DIFF
--- a/docker/test/integration/hive_server/http_api_server.py
+++ b/docker/test/integration/hive_server/http_api_server.py
@@ -48,13 +48,13 @@ def upload_file():
         # empty file without a filename.
         if file.filename == "":
             flash("No selected file")
-            return redirect(request.url)
+            return redirect(url_for("upload_file"))
         if file and allowed_file(file.filename):
             filename = secure_filename(file.filename)
             fullpath = os.path.normpath(os.path.join(app.config["UPLOAD_FOLDER"], filename))
             if not fullpath.startswith(os.path.abspath(app.config["UPLOAD_FOLDER"])):
                 flash("Invalid file path")
-                return redirect(request.url)
+                return redirect(url_for("upload_file"))
             file.save(fullpath)
             return redirect(url_for("upload_file", name=filename))
     return """


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/142](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/142)

To fix the issue, we need to validate the `request.url` before using it in a redirect. A safer approach is to redirect users to a predefined safe URL (e.g., the home page or the upload page) instead of relying on `request.url`. Alternatively, we can validate the URL to ensure it does not contain an explicit host or other unsafe components.

In this case, the simplest and most secure fix is to replace `request.url` with a predefined safe URL, such as the upload page (`url_for("upload_file")`). This ensures that the redirect always points to a known safe location.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
