### PR TITLE
Potential fix for code scanning alert no. 140: HTTP Response Splitting

### DIFF
--- a/tests/integration/test_storage_url_http_headers/redirect_server.py
+++ b/tests/integration/test_storage_url_http_headers/redirect_server.py
@@ -1,6 +1,6 @@
 import http.server
 import sys
-
+from urllib.parse import quote
 REDIRECT_HOST = ""
 REDIRECT_PORT = 0
 
@@ -21,7 +21,8 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         else:
             global REDIRECT_HOST, REDIRECT_PORT
             self.send_response(302)
-            target_location = f"http://{REDIRECT_HOST}:{REDIRECT_PORT}{self.path}"
+            sanitized_path = quote(self.path)
+            target_location = f"http://{REDIRECT_HOST}:{REDIRECT_PORT}{sanitized_path}"
             self.send_header("Location", target_location)
             self.end_headers()
             self.wfile.write(b'{"status":"redirected"}')


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/140](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/140)

To fix the issue, we need to sanitize the `self.path` value before using it to construct the `target_location` variable. Specifically, we should remove or encode any characters that could lead to HTTP response splitting, such as line breaks (`\n`, `\r`) or other special characters like `:`. 

The best approach is to use a library function or a custom sanitization function to ensure the path is safe. In this case, we can use `urllib.parse.quote` to encode the path safely, which will escape any unsafe characters.

Changes to be made:
1. Import `urllib.parse.quote` at the top of the file.
2. Replace the direct use of `self.path` in `target_location` with a sanitized version using `urllib.parse.quote`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
