### PR TITLE
Potential fix for code scanning alert no. 139: HTTP Response Splitting

### DIFF
--- a/tests/integration/helpers/s3_mocks/broken_s3.py
+++ b/tests/integration/helpers/s3_mocks/broken_s3.py
@@ -386,7 +386,8 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         self.read_all_input()
 
         self.send_response(307)
-        url = f"http://{host}:{port}{self.path}"
+        sanitized_path = urllib.parse.quote(self.path, safe="/?&=")
+        url = f"http://{host}:{port}{sanitized_path}"
         self.log_message("redirect to %s", url)
         self.send_header("Location", url)
         self.end_headers()


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/139](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/139)

To fix the issue, sanitize the `self.path` variable to ensure it does not contain any line break characters (`\n` or `\r`) or other potentially dangerous characters (e.g., `:`). This can be achieved by replacing or removing such characters before constructing the `url` variable.

The best approach is to use Python's `urllib.parse.quote` to encode the path safely, ensuring that it is properly escaped and does not contain unsafe characters. This method is robust and prevents injection vulnerabilities.

Changes will be made to the `redirect` method in the `RequestHandler` class:
1. Import `urllib.parse.quote` if not already imported.
2. Sanitize `self.path` using `urllib.parse.quote` before constructing the `url`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
