### PR TITLE
Potential fix for code scanning alert no. 134: Binding a socket to all network interfaces

### DIFF
--- a/tests/integration/helpers/proxy1.py
+++ b/tests/integration/helpers/proxy1.py
@@ -62,7 +62,7 @@ class Proxy1:
     def start(self, address):
         self._address = address
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._sock.bind(("", 0))
+        self._sock.bind(("127.0.0.1", 0))
         self._sock.listen(1)
         self._runner = threading.Thread(target=self._run)
         self._runner.start()


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/134](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/134)

To fix the issue, the socket should be bound to a specific interface instead of all interfaces. Since this code is likely used in a testing environment, binding to `127.0.0.1` (localhost) is a secure and appropriate choice. This ensures that the socket only accepts connections from the local machine, reducing the risk of unauthorized access.

The changes will be made to line 65, where `self._sock.bind(("", 0))` will be replaced with `self._sock.bind(("127.0.0.1", 0))`. This modification ensures that the socket is bound to the localhost interface.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
