### PR TITLE
Potential fix for code scanning alert no. 132: Binding a socket to all network interfaces

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -158,7 +158,7 @@ def run_and_check(
 def is_port_free(port: int) -> bool:
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", port))
+            s.bind(("127.0.0.1", port))
             return True
     except socket.error:
         return False


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/132](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/132)

To fix the issue, we will modify the `is_port_free` function to bind the socket to the loopback interface (`127.0.0.1`) instead of all interfaces. This ensures that the socket is only accessible locally during the port availability check, mitigating the security risk. The change will involve replacing `s.bind(("", port))` with `s.bind(("127.0.0.1", port))`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
