### PR TITLE
Potential fix for code scanning alert no. 120: URL redirection from remote source

### DIFF
--- a/docker/test/integration/hive_server/http_api_server.py
+++ b/docker/test/integration/hive_server/http_api_server.py
@@ -42,7 +42,7 @@ def upload_file():
         # check if the post request has the file part
         if "file" not in request.files:
             flash("No file part")
-            return redirect(request.url)
+            return redirect(url_for("upload_file"))
         file = request.files["file"]
         # If the user does not select a file, the browser submits an
         # empty file without a filename.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/120](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/120)

To fix the issue, we need to avoid directly using `request.url` in the redirect. Instead, we can redirect the user to a safe, predefined URL (e.g., the upload page) when an error occurs. This ensures that the redirection target is controlled and not influenced by user input. Specifically, replace `redirect(request.url)` on line 45 with `redirect(url_for("upload_file"))`, which redirects to the `/upload` endpoint.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
