### PR TITLE
Potential fix for code scanning alert no. 116: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -1,5 +1,7 @@
 # yamllint disable rule:comments-indentation
 name: ReleaseBranchCI
+permissions:
+  contents: read
 
 env:
   # Force the stdout and stderr streams to be unbuffered


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/116](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/116)

To fix the issue, we will add a `permissions` key at the root level of the workflow file. This will apply the specified permissions to all jobs in the workflow unless overridden at the job level. Based on the workflow's functionality, we will grant `contents: read` permission, which is sufficient for most CI workflows that only need to check out the repository code. If any job requires additional permissions, they can be defined specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
