### PR TITLE
Potential fix for code scanning alert no. 90: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -2,6 +2,8 @@
 # https://github.com/orgs/community/discussions/9050
 
 name: Testing workflow
+permissions:
+  contents: read
 'on':
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/90](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/90)

To fix the issue, we need to add a `permissions` key to the workflow. Since the workflow primarily interacts with repository contents (e.g., checking out code) and uses secrets, we can set the permissions to `contents: read` at the workflow level. This ensures the workflow has the minimum required permissions to function while adhering to the principle of least privilege.

The `permissions` key should be added at the root level of the workflow file, above the `jobs` section. This will apply the permissions to all jobs in the workflow unless overridden at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
