### PR TITLE
Potential fix for code scanning alert no. 89: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reusable_test_stage.yml
+++ b/.github/workflows/reusable_test_stage.yml
@@ -2,6 +2,8 @@ env:
   PYTHONUNBUFFERED: 1
 
 name: StageWF
+permissions:
+  contents: read
 
 'on':
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/89](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/89)

To fix the issue, we will add a `permissions` key at the workflow level to define the least privileges required. Based on the provided workflow, it appears that the workflow primarily reads inputs and secrets, and there is no indication of write operations. Therefore, we will set `contents: read` as the default permission. If additional permissions are required by the reusable workflow, they should be explicitly added here.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
