### PR TITLE
Potential fix for code scanning alert no. 82: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reusable_build_stage.yml
+++ b/.github/workflows/reusable_build_stage.yml
@@ -5,6 +5,8 @@ env:
   PYTHONUNBUFFERED: 1
 
 name: BuildStageWF
+permissions:
+  contents: read
 
 'on':
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/82](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/82)

To fix the issue, we need to explicitly define permissions for the workflow or the job. Since the workflow appears to perform build-related tasks and uses secrets, the most appropriate permissions are likely `contents: read`. This allows the workflow to read repository contents without granting unnecessary write permissions. If additional permissions are required for specific tasks, they can be added incrementally.

The fix involves adding a `permissions` key at the workflow level or job level. In this case, adding it at the workflow level ensures all jobs inherit the same permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
