### PR TITLE
Potential fix for code scanning alert no. 72: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -45,6 +45,8 @@ jobs:
   Build:
     name: Build-${{inputs.build_name}}
     if: ${{ contains(fromJson(inputs.data).jobs_data.jobs_to_do, inputs.build_name) || inputs.force }}
+    permissions:
+      contents: read
     env:
       GITHUB_JOB_OVERRIDDEN: Build-${{inputs.build_name}}
     runs-on: [self-hosted, '${{inputs.runner_type}}']


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/72](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/72)

To fix the issue, we need to add a `permissions` key to the workflow or job level to explicitly define the least privileges required. Based on the operations performed in the workflow, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- Additional permissions can be added if specific steps require them (e.g., `issues: write` or `pull-requests: write`).

The `permissions` key can be added at the workflow level (to apply to all jobs) or at the job level (to apply to specific jobs). In this case, adding it at the job level ensures granular control.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
