### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,6 @@
 name: NightlyBuilds
+permissions:
+  contents: read
 
 env:
   # Force the stdout and stderr streams to be unbuffered


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/64](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/64)

To fix the issue, we will add a `permissions` key at the workflow level to define the least privileges required for all jobs. Since the workflow primarily reads repository contents and does not perform write operations, we will set `contents: read`. This ensures the workflow has only the necessary permissions to function correctly.

The `permissions` key will be added at the top level of the workflow, just below the `name` field, so it applies to all jobs unless overridden at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
