### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,5 +1,7 @@
 # yamllint disable rule:comments-indentation
 name: MasterCI
+permissions:
+  contents: read
 
 env:
   # Force the stdout and stderr streams to be unbuffered


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/39](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/39)

To fix the issue, we will add a `permissions` key at the root level of the workflow to define the least privileges required for all jobs. Since the workflow primarily involves running scripts and does not appear to require write access, we will set `contents: read`. If any specific job requires additional permissions, we will define them under the `permissions` key for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
