### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -1,6 +1,9 @@
 # yamllint disable rule:comments-indentation
 name: BackportPR
 
+permissions:
+  contents: read
+
 env:
   # Force the stdout and stderr streams to be unbuffered
   PYTHONUNBUFFERED: 1


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/49](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/49)

To fix the issue, we will add a `permissions` key at the root level of the workflow file. This will apply the specified permissions to all jobs in the workflow unless overridden by job-specific permissions. Based on the operations performed in the workflow (e.g., checking out code, running scripts), the minimum required permissions are `contents: read`. If any job requires additional permissions (e.g., `contents: write`), they can be defined at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
