### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -1,5 +1,7 @@
 # yamllint disable rule:comments-indentation
 name: MergeQueueCI
+permissions:
+  contents: read
 
 env:
   # Force the stdout and stderr streams to be unbuffered


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/40](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/40)

To fix the issue, we will add a `permissions` key at the root level of the workflow to define the minimum required permissions for all jobs. Based on the workflow's operations, the `contents: read` permission is sufficient for most jobs, as they primarily read repository data. If any job requires additional permissions (e.g., `pull-requests: write`), we will define them specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
