### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker_test_images.yml
+++ b/.github/workflows/docker_test_images.yml
@@ -1,5 +1,8 @@
 name: Build docker images
 
+permissions:
+  contents: read
+
 'on':
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/14](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/14)

To fix the issue, we will add a `permissions` key at the workflow level to define the minimum required permissions. Based on the workflow's operations, it primarily checks out code and runs Python scripts. These actions only require `contents: read` permission. We will set this permission at the root of the workflow to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
