### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -1,4 +1,6 @@
 name: JepsenWorkflow
+permissions:
+  contents: read
 env:
   # Force the stdout and stderr streams to be unbuffered
   PYTHONUNBUFFERED: 1


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/19](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/19)

To fix the issue, we will add a `permissions` key at the workflow level to define the least privileges required for the workflow. Based on the actions used in the workflow:
- The `contents: read` permission is sufficient for checking out the repository code.
- No other permissions appear to be required based on the provided workflow steps.

The `permissions` key will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
