### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto_releases.yml
+++ b/.github/workflows/auto_releases.yml
@@ -1,5 +1,9 @@
 name: AutoReleases
 
+permissions:
+  contents: write
+  statuses: write
+
 env:
   PYTHONUNBUFFERED: 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/10](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/10)

To fix the issue, we will add a `permissions` key at the root level of the workflow to define the least privileges required for all jobs. Based on the operations performed in the workflow:
- The `contents: read` permission is required to check out the repository code.
- The `contents: write` permission is required for creating releases.
- The `statuses: write` permission is required for posting branch statuses.

We will also ensure that no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
