### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -1,5 +1,8 @@
 name: CherryPick
 
+permissions:
+  contents: read
+
 env:
   # Force the stdout and stderr streams to be unbuffered
   PYTHONUNBUFFERED: 1


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/2](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/2)

To fix the issue, we need to add a `permissions` key to the workflow file. This key should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions:
- It checks out repository code, which requires `contents: read`.
- It uses secrets and runs scripts, but these do not require additional permissions beyond `contents: read`.

The `permissions` key should be added at the root level of the workflow to apply to all jobs, as there is only one job (`CherryPick`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
