### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,5 +1,10 @@
 name: CreateRelease
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
 concurrency:
   group: release
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/15](https://github.com/Git-Hub-Chris/ClickHouse/security/code-scanning/15)

To fix the issue, we will add a `permissions` key at the workflow level to define the least privileges required for the workflow. Based on the operations performed in the workflow, the following permissions are necessary:
- `contents: write` for pushing tags, creating branches, and updating files.
- `pull-requests: write` for creating pull requests.
- `actions: read` for interacting with GitHub Actions artifacts.

These permissions will be added at the root of the workflow file to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
